### PR TITLE
add the opengl wx support library in the monolithic mode

### DIFF
--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -95,6 +95,13 @@ public:
     bool is_cxxflags_set() const { return m_flags & kIsCxxFlags; }
     bool is_debug() const { return m_flags & kIsDebug; }
     bool is_create_cmake_file() const { return m_flags & kCMakeIncludeFile; }
+
+    bool contains_lib(const string& lib) const
+    {
+        return std::find_if(m_libs.begin(), m_libs.end(),
+                   [&lib](const string& libname) -> bool { return libname == lib; }) != m_libs.end();
+    }
+
 };
 
 #endif // UTILS_HPP

--- a/src/wx-config.cpp
+++ b/src/wx-config.cpp
@@ -124,6 +124,15 @@ void add_libs(const CommandLineParser& parser, const string& config, const strin
         // example: libwxmsw31u.a or libwxmsw31ud.a
         libname << "wxmsw" << build_cfg["WXVER_MAJOR"] << build_cfg["WXVER_MINOR"] << unicode_suffix;
         ss << "-l" << libname.str() << " ";
+        // in the monolithic mode, there are usually two lib files, the common is libwxmsw32u.a, the other file is libwxmsw32u_gl.a
+        // this means the wx's opengl support library is always a seperate library, so check to see whether the "gl" option is added
+        // finally, we got the linker option line such as: "-lwxmsw32u -lwxmsw32u_gl"
+        const auto& libs = parser.get_libs();
+        for(const auto& lib : libs) {
+            if(lib == "gl") {
+                ss << "-l" << libname.str() << "_gl" << " ";
+            } 
+        }
     } else {
         // translate lib name to file name
         const auto& libs = parser.get_libs();

--- a/src/wx-config.cpp
+++ b/src/wx-config.cpp
@@ -127,11 +127,8 @@ void add_libs(const CommandLineParser& parser, const string& config, const strin
         // in the monolithic mode, there are usually two lib files, the common is libwxmsw32u.a, the other file is libwxmsw32u_gl.a
         // this means the wx's opengl support library is always a seperate library, so check to see whether the "gl" option is added
         // finally, we got the linker option line such as: "-lwxmsw32u -lwxmsw32u_gl"
-        const auto& libs = parser.get_libs();
-        for(const auto& lib : libs) {
-            if(lib == "gl") {
-                ss << "-l" << libname.str() << "_gl" << " ";
-            } 
+        if (parser.contains_lib("gl")) {
+            ss << "-l" << libname.str() << "_gl" << " ";
         }
     } else {
         // translate lib name to file name


### PR DESCRIPTION
This solves the issue reported here:
when I'm using self build wx debug 3.2, and has the option "--libs std,gl", I don't see the linker option -lwxmsw32ud_gl get generated Issue #16 https://github.com/eranif/wx-config-msys2/issues/16